### PR TITLE
Improvements to the syntax highlighting for shell, yaml and markdown

### DIFF
--- a/colors/ghdark.vim
+++ b/colors/ghdark.vim
@@ -115,13 +115,13 @@ function! s:ghhl(group, guifg, ...)
     else
         let style = "NONE"
     endif
-    
+
     let hi_str = [ "hi", a:group,
             \ 'guifg=' . fg[0], "ctermfg=" . fg[1],
             \ 'guibg=' . bg[0], "ctermbg=" . bg[1],
             \ 'gui=' . style, "cterm=" . style
             \ ]
-    
+
     execute join(hi_str, ' ')
 endfunction
 
@@ -140,12 +140,16 @@ call s:ghhl("GhBase3", "base3")
 call s:ghhl("GhBase4", "base4")
 call s:ghhl("GhBase5", "base5")
 call s:ghhl("GhRed", "red")
-call s:ghhl("GhPurpUnder", "purp", "none", "underline")
-call s:ghhl("GhOrange", "orange")
-call s:ghhl("GhLightBlue", "lightblue")
-call s:ghhl("GhBlue", "blue")
-call s:ghhl("GhBlueItalic", "blue", "none", "italic")
+call s:ghhl("GhRedItalic", "red", "none", "italic")
 call s:ghhl("GhPurp", "purp")
+call s:ghhl("GhPurpUnder", "purp", "none", "underline")
+call s:ghhl("GhBlue", "blue")
+call s:ghhl("GhBlueUnder", "blue", "none", "underline")
+call s:ghhl("GhBlueBold", "blue", "none", "bold")
+call s:ghhl("GhBlueItalic", "blue", "none", "italic")
+call s:ghhl("GhOrange", "orange")
+call s:ghhl("GhOrangeBold", "orange", "none", "bold")
+call s:ghhl("GhLightBlue", "lightblue")
 call s:ghhl("GhGreen", "green")
 call s:ghhl("GhUnder", "none", "none", "underline")
 call s:ghhl("GhBold", "none", "none", "bold")
@@ -215,7 +219,7 @@ hi! link NonText Ignore
 hi! link Number GhBlue
 hi! link Operator GhBlue
 hi! link PreCondit PreProc
-hi! link PreProc GhBase5
+hi! link PreProc GhBlue
 hi! link Question GhBase4
 hi! link Quote StringDelimiter
 hi! link Repeat GhPurp
@@ -428,17 +432,19 @@ hi! link jsTernaryIfOperator jsDot
 
 " markdown
 
-call s:ghhl("markdownH1", "base5", "none", "bold")
+hi! link markdownH1 GhOrangeBold
 hi! link markdownH2 markdownH1
 hi! link markdownH3 markdownH1
 hi! link markdownH4 markdownH1
 hi! link markdownH5 markdownH1
+hi! link markdownHeadingDelimiter GhBlueBold
+hi! link markdownDelimiter GhOrange
 hi! link markdownCode GhLightBlue
 hi! link markdownCodeDelimiter GhLightBlue
 hi! link markdownInlineCode markdownCode
-hi! link markdownListMarker GhRed
-hi! link markdownLinkText GhPurpUnder
-hi! link markdownUrl GhBlueItalic
+hi! link markdownListMarker GhOrange
+hi! link markdownLinkText GhBlueUnder
+hi! link markdownUrl GhRedItalic
 hi! link markdownLinkUrl markdownUrl
 hi! link markdownBold GhBold
 hi! link markdownItalic GhItalic
@@ -503,8 +509,8 @@ hi! link scssVariableValue Operator
 hi! link shAlias shVariable
 hi! link shCaseLabel Type
 hi! link shDerefPPS Keyword
-hi! link shDeref shVariable
-hi! link shDerefSimple shVariable
+hi! link shDeref GhBlue
+hi! link shDerefSimple GhBlue
 hi! link shDoubleQuote shQuote
 hi! link shEcho GhBlue
 hi! link shEcho Normal
@@ -519,7 +525,7 @@ hi! link shRedir Keyword
 hi! link shSetList shFunctionOne
 hi! link shSnglCase shParen
 hi! link shStatement Keyword
-hi! link shVariable Normal
+hi! link shVariable GhRed
 hi! link shWrapLineOperator shParen
 
 " swift
@@ -528,7 +534,7 @@ hi! link swiftFuncDef FunctionDef
 hi! link swiftIdentDef IdentifierDef
 hi! link swiftLibraryFunc LibraryFunc
 hi! link swiftLibraryProp LibraryIdent
-hi! link swiftLibraryType LibraryType
+ hi! link swiftLibraryType LibraryType
 hi! link swiftUserFunc LocalFunc
 hi! link swiftUserProp LocalIdent
 hi! link swiftUserType LocalType
@@ -616,7 +622,7 @@ hi! link Whitespace Ignore
 " yaml
 
 hi! link yamlKey GhGreen
-hi! link yamlConstant GhBlue
+hi! link yamlConstant GhRed
 
 " nerdtree
 

--- a/colors/ghdark.vim
+++ b/colors/ghdark.vim
@@ -438,7 +438,6 @@ hi! link markdownH3 markdownH1
 hi! link markdownH4 markdownH1
 hi! link markdownH5 markdownH1
 hi! link markdownHeadingDelimiter GhBlueBold
-hi! link markdownDelimiter GhOrange
 hi! link markdownCode GhLightBlue
 hi! link markdownCodeDelimiter GhLightBlue
 hi! link markdownInlineCode markdownCode


### PR DESCRIPTION
Hi,

First of all, thanks a lot for your wonderful work with the `ghdark` theme!

This PR aims to improve the syntax highlighting for `shell`, `yaml` and `markdown`.
Indeed, in my honest (and humble) opinion, I find that syntax highlighting for those three languages lacks coloration and is a bit too "neutral".
All the changes I made use the included colors in `ghdark`, I didn't add any additional one.

*By the way, I'm aware that these "improvements" might be totally subjectives. I would totally understand if you don't want to merge them to `ghdark` because you want it to stay as it is today. If you prefer, I can eventually create my own inspired/forked from `ghdark` theme with those changes, so they won't have to be implemented in `ghdark` directly.*

Here are the changes I made:

### General
- I added a few color types in the "set the colors" section from already existing colors (such as `GhRedItalic`or `GhBlueUnder` for instance).
- I re-ordered the colors' calls in the "set the colors" section so they are sorted by colors (for instance: `GhRed` is followed by `GhRedItalic`; `GhBlue` precedes `GhBlueUnder`, `GhBlueBold` and `GhBlueItalic`; ...)
- I changed the `Number` parameter in the "links" section from `GhBlue` to `GhOrange` to identify numbers more easily, specifically in `shell` and `yaml` (see the [shell section below](#shell) and the [yaml section below](#yaml)).
- I changed the `PreProc` parameter in the "links" section from `GhBase5`(white) to `GhBlue` so it is easier to identify variables in `shell` (see the [shell section below](#shell))

### Shell
- I changed the `shVariable` parameter from `Normal` to `GhRed` so it is easier to notice the variables' names when they are declared.
- I changed the `shDeref` and `shDerefSimple` parameters from `shVariable` (Normal) to `GhBlue`. In addition to the change I made to the `PreProc` parameter (see the [General section above](#General)), it is easier to notice called variables inside a shell script.
- The numbers used outside a comment or an `echo` are now using the `GhOrange` color thanks to the change I made in the `Number` parameters (see the [General section above](#General)). It makes them easier to identify, specifically for "exit codes".

**From left to right, my changes vs the original version**
  
![image](https://user-images.githubusercontent.com/53110319/192562737-e93790da-dfa3-494c-abf1-2ea55dc74975.png)
  
### Yaml
- I changed the `yamlConstant` parameter from `GhBlue` to `GhRed` in order to make yaml constants differ from basic yaml declaration instead of being blue as well (notice the difference between the "true" constants in the screenshot below).
- The numbers used outside a comment are now using the `GhOrange` color thanks to the change I made in the `Number` parameter (see the [General section above](#General)). It makes them easier to identify and differs from basic yaml declaration instead of being blue as well.
  
**From left to right, my changes vs the original version**  
  
![image](https://user-images.githubusercontent.com/53110319/192566480-64412665-449b-4829-a13b-137c5ad51054.png)
  
### Markdown
- I changed the `markdownH1` parameter from `base5 bold` to `GhOrangeBold` (which I created in the "set the colors" section instead of using the "color call" declared directly in the "markdown" section). so it is easier to identify titles.
- I added the `markdownHeadingDelimiter` parameter and make it use the `GhBlueBold` color I declared in the "set the colors" section. It also makes titles easier to identify.
- I modified the color of the `markdownListMarker` parameter from `GhRed` to `GhOrange`, the `markdownLinkText` parameter from `GhPurpUnder` to `GhBlueUnder` and the `markdownUrl` from `GhBlueItalic` to `GhRedItalic` to better fit the syntax highlighting of other languages (I felt like the markdown syntax highlighting felt off/too neutral compared to the other ones).

**From left to right, my changes vs the original version**  

![image](https://user-images.githubusercontent.com/53110319/192573768-302ac359-bf38-4918-a603-db7f8bdaa004.png)

And there we go! :smile:

As I said earlier, I'm aware that these "improvements" might be totally subjectives. If you want me to make my own inspired/forked from `ghdark` theme with those changes instead of merging them directly to `ghdark`, just let me know. I would totally understand.  

What do you think?
